### PR TITLE
Convert tests from QUnit to Mocha 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,39 @@
 {
-  "name"          : "FlatJS",
-  "description"   : "Markup driven MV* JS Framework built with progressive enhancement & limited boilerplate code in mind.",
-  "url"           : "http://sankho.github.io/FlatJS",
-  "keywords"      : ["model", "view", "resource", "component", "server", "client", "browser"],
-  "author"        : "Sankho Mallik <sankho.mallik@gmail.com>",
+  "name": "FlatJS",
+  "description": "Markup driven MV* JS Framework built with progressive enhancement & limited boilerplate code in mind.",
+  "url": "http://sankho.github.io/FlatJS",
+  "keywords": [
+    "model",
+    "view",
+    "resource",
+    "component",
+    "server",
+    "client",
+    "browser"
+  ],
+  "author": "Sankho Mallik <sankho.mallik@gmail.com>",
   "devDependencies": {
     "node-qunit-phantomjs": "0.2.1",
     "docker": "0.2.13"
   },
   "scripts": {
+    "test": "mocha-phantomjs test/index.html",
     "tests": "node-qunit-phantomjs ./tests/index.html --verbose",
     "build": "uglifyjs ./src/FlatJS.js ./src/FlatJS.Classy.js ./src/FlatJS.Runner.js ./src/FlatJS.Helpers.js ./src/FlatJS.Widget.js ./src/FlatJS.Dispatch.js ./src/FlatJS.Resource.js ./src/FlatJS.Component.js  --mangle -o flat-min.js; uglifyjs ./src/FlatJS.js ./src/FlatJS.Classy.js ./src/FlatJS.Runner.js ./src/FlatJS.Helpers.js ./src/FlatJS.Widget.js ./src/FlatJS.Dispatch.js ./src/FlatJS.Resource.js ./src/FlatJS.Component.js  --beautify -o flat.js",
-   "docs": "rm -rf ./docs && docker -o ./docs -i ./src; docker -o ./docs/todomvc/ -i ./examples/todomvc/js/"
+    "docs": "rm -rf ./docs && docker -o ./docs -i ./src; docker -o ./docs/todomvc/ -i ./examples/todomvc/js/"
   },
-  "main"          : "flat-min.js",
-  "version"       : "0.0.9",
-  "license"       : "DWTFYWT",
+  "main": "flat-min.js",
+  "version": "0.0.9",
+  "license": "DWTFYWT",
   "repository": {
     "type": "git",
     "url": "https://github.com/sankho/FlatJS.git"
+  },
+  "dependencies": {
+    "chai": "^2.2.0",
+    "jquery": "^2.1.3",
+    "mocha": "^2.2.4",
+    "mocha-phantomjs": "^3.5.3",
+    "phantomjs": "^1.9.16"
   }
 }

--- a/test/Classy/Classy.tests.js
+++ b/test/Classy/Classy.tests.js
@@ -1,0 +1,128 @@
+// should contain all unit tests on FlatJS.Classy.js
+describe('All unit tests on FlatJS.Classy.js', function() {
+  
+  it("FlatJS.Classy existence tests", function() {
+
+    assert.equal(typeof FlatJS.Classy, 'function', "FlatJS.Classy exists, is a function");
+    assert.equal(typeof FlatJS.Classy.extend, 'function', 'FlatJS.Classy.extend exists, is a function');
+
+  });
+
+  it("FlatJS.Classy OOP tests - class extension, basic functionality", function() {
+
+    var Shape = FlatJS.Classy.extend({
+
+      area: 0,
+
+      init: function(area) {
+        this.area = area;
+      },
+
+      getArea: function() {
+        return this.area;
+      }
+
+    });
+
+    Shape.staticFn = function() {
+      return "static string";
+    }
+
+    var Rect = Shape.extend({
+
+      init: function(width, height) {
+        this.width = width;
+        this.height = height;
+
+        this._super(width * height);
+      },
+
+      width: 0,
+      height: 0,
+
+    });
+
+    var Square = Rect.extend({
+
+      init: function(side) {
+        this._super(side, side);
+      }
+
+    });
+
+    Square.staticFn = function() {
+      return "overridden string";
+    }
+
+    var exRect = new Rect(5, 2);
+    var exSquare = new Square(5);
+
+    assert.ok(typeof Rect === 'function', "Rect is a class")
+    assert.ok(typeof Rect.extend === 'function', "Rect is extendable")
+
+    assert.ok(exRect instanceof Rect, "exRect identified as an instance of class Rect")
+    assert.ok(exRect instanceof Shape, "exRect identified as an instance of class Shape")
+
+    assert.equal(Rect.staticFn(), "static string", "Static functions are extended")
+    assert.equal(Square.staticFn(), "overridden string", "Static functions can be overriden")
+
+    assert.equal(exRect.width, 5, "Rectangle width should be 5")
+    assert.equal(exRect.height, 2, "Rectangle height should be 2")
+    assert.equal(exRect.getArea(), 10, "Rectangle area should be 10");
+
+    assert.ok(exSquare instanceof Rect, "exSquare identified as an instance of class Rect")
+    assert.ok(exSquare instanceof Square, "exSquare identified as an instance of class Square")
+    assert.ok(exSquare instanceof Shape, "exSquare identified as an instance of class Shape")
+
+    assert.equal(exSquare.width, 5, "Square width should be 5")
+    assert.equal(exSquare.height, 5, "Square height should be 5")
+    assert.equal(exSquare.getArea(), 25, "Square area should be 25")
+
+  });
+
+  it("FlatJS.Classy OOP tests - private member functions & psuedo private storage", function() {
+
+    var exClass = FlatJS.Classy.extend(function() {
+
+      function privateFunction() {
+        return this._('string');
+      }
+
+      return {
+        init: function(string) {
+          this._('string', string);
+        },
+
+        callPrivateFunction: function() {
+          return this._(privateFunction)();
+        }
+
+      }
+
+    });
+
+    var exObj = new exClass("boosh");
+    var exObj2 = new exClass("boosy");
+
+    assert.equal(typeof exObj.callPrivateFunction, 'function', "FlatJS.Classy objects can be extended by passing a function as well");
+
+    assert.equal(exObj.callPrivateFunction(), "boosh", "exObj can call a private function from a public function, get private variable set on init")
+    assert.equal(exObj._('string'), "boosh", "psuedo private storage working on object")
+
+    assert.equal(exObj2.callPrivateFunction(), "boosy", "exObj2 can call a private function from a public function, get private variable set on init")
+    assert.equal(exObj2._('string'), "boosy", "psuedo private storage working on object")
+    assert.equal(typeof privateFunction, 'undefined', "Private function should be out of this scope");
+
+  });
+
+  it("FlatJS.Classy storage tests - created objects should be retained & referenceable statically", function() {
+
+    var exClass = FlatJS.Classy.extend(),
+      exChild = new exClass();
+
+    assert.equal(typeof exClass.fjsObjects, 'object', "Created classes should have an array attached called objects");
+    assert.equal(exClass.fjsObjects[0], exChild, "First item in created class's objects array matches created chidl");
+
+  });
+
+});

--- a/test/Component/Component.tests.js
+++ b/test/Component/Component.tests.js
@@ -1,0 +1,343 @@
+// should contain all unit tests on FlatJS.Component.js
+describe('FlatJS.Component.js', function() {
+  
+    var __MVMockData;
+    var $mock, $moc2, mock, mock2;
+    var mvMod, mvMod2;
+
+    before(function(done) {
+      __MVMockData = {
+        HTML: '',
+        customMV: FlatJS.Component || {}
+      }
+
+      $.ajax({
+
+        url: 'Component/mock.html',
+        success: function(data) {
+          __MVMockData.HTML = data;
+          $('#mock-area').append(data);
+          
+          $mock = $('#flat-mv-test-mock .first'),
+          $moc2 = $('#flat-mv-test-mock .second'),
+          mock = $mock.get(0),
+          mock2 = $moc2.get(0);
+
+          new FlatJS.Runner({
+            attr: 'data-js-mv-test-module'
+          });
+
+          mvMod = mock.fjsComponents ? mock.fjsComponents['FlatJS.Component'] : null;
+          mvMod2 = mock2.fjsComponents ? mock2.fjsComponents['FlatJS.Component'] : null;
+          
+          done();
+        }
+      });
+    });
+
+    it("FlatJS.Component existence tests", function() {
+      var $mock = $('#flat-mv-test-mock');
+      assert.equal($mock.length, 1, 'Mock successfully AJAXed in');
+      assert.equal(typeof FlatJS.Component, 'function', "FlatJS.Component exists, is a function");
+      assert.ok(mvMod instanceof FlatJS.Widget, 'FlatJS.Component is an instance of FlatJS.Widget');
+    });
+
+    it("FlatJS.Component tests - DOM loaded model generation & JSON data assembly from markup", function() {
+      assert.equal(typeof APP.Todo, 'function', "APP.Todo model references should be automatically generated");
+      assert.equal(typeof APP.Person, 'function', "APP.Person model references should be automatically generated");
+      assert.equal(APP.Todo.fjsObjects.length, 4, "APP.Todo.fjsObjects has 4 todos in it");
+      assert.equal(APP.Person.fjsObjects.length, 2, "APP.Person.fjsObjects has 2 people in it");
+      assert.equal(APP.Person.fjsObjects[0].name, "Jane", "APP.Person.fjsObjects[0] has correct data on name")
+      assert.equal(APP.Todo.fjsObjects[0].title, "Get Laundry", "APP.Todo.fjsObjects[0] has correct data on title")
+      assert.equal(APP.Person.fjsObjects[0].title, undefined, "Person object does not inherit Todo information even though markup is nested.")
+      assert.equal(APP.Todo.find(3).somethingExtra, "hey", "camel case conversion working on data-mv-key");
+
+      assert.equal(APP.Todo.find(1).arbitrary, 'key values', "JSON extention of object via data-mv-json key on node successful");
+      assert.equal($mock.find('h2').text(), "Jane", "Correct name applied to first instance of model in view, updated from entry of second");
+
+      assert.equal(typeof mvMod.fjsData, "object", "JSON object created & attached to mod");
+      assert.equal(mvMod.fjsData.you, APP.Person.find(2), "JSON object successfully creates pointers to related Person model objects")
+      assert.equal(mvMod.fjsData.header.title, "Todo List", "Non model string data saved to JSON object as well")
+      assert.equal(mvMod.fjsData.people[0].personObj, APP.Person.find(1), "Models are saved as relations to the JSON object, pushed onto array as well, camel case conversion working on data-json-obj")
+      assert.equal(typeof mvMod.fjsData.people[0].todos, 'object', 'Todos successfully  added to individual people object');
+      assert.equal(mvMod.fjsData.people[1].todos.length, 4, "Basic arrays are saving basic objects based on markup within arrays");
+      assert.equal(mvMod.fjsData.people[1].todos[0].title, "Get Dinner", "Correct object in basic arrays within arrays");
+      assert.equal(mvMod.fjsData.header.arbitraryTopTitle, "Hey now", "Camel case conversion taking place for data-json-key");
+
+    });
+
+    it('FlatJS.Component - CSS Classes are added on attribute check', function() {
+      assert.ok($mock.find('.first-todo:eq(0)').hasClass('completed'), 'Classes added if array passed to attribute defining a key value match and a class name.');
+      assert.ok($moc2.find('li:eq(0)').hasClass('not-completed'), 'Default / secondary classes added if array passed to attribute defining a key value non match and a class name corrseponding to that lack of match. Words.');
+      assert.ok(APP.Todo.find(31).completed, "Model set by fjs-class statement + class existence");
+      assert.ok($moc2.find('li:eq(1)').hasClass('not-completed') && $moc2.find('li:eq(1)').hasClass('whatever'), 'Multiple class assertions successfully made on object if double sided array passed.');
+
+      APP.Todo.find(31).set('completed', true);
+      assert.ok($('[fjs-id="31"]').hasClass('completed'), "fjs-class attributes are bound to resource object changes");
+
+      assert.ok($mock.find('#root-class-swap').hasClass('false'), "fjs-class attribtues updates class HTML when given markup that isn't consistent with data model")
+      mvMod.fjsData.set('arbitraryRootKey', 'Not Valuable');
+      assert.ok($mock.find('#root-class-swap').hasClass('true'), "fjs-class attributes work when set to listen to objects on the root of fjsData variable");
+
+      mvMod.fjsData.set('header.arbitraryTopTitle2', 'Hey Hey');
+      assert.equal($mock.find('h5:eq(1)').text(), 'Hey Hey', 'Dom elements bound to nested variables off root fjsData variable');
+      assert.ok($mock.find('#inner-item-class-swap').hasClass('true'), 'fjs-class attributes work when set to listen to objects nested within the root fjsData variable');
+
+    });
+
+    it("FlatJS.Component - Changing model objects should update HTML", function() {
+      APP.Todo.fjsObjects[0].set('title', 'Cook Dinner');
+      APP.Todo.find(2).set('title', 'Cook Lasagana');
+      assert.equal($('.first .first-todo span').text(), 'Cook Dinner', "HTML syncs on object change successfully - first item");
+      assert.equal($('.second .first-todo span').text(), 'Cook Lasagana', "HTML syncs on object change successfully - first item");
+    });
+
+    it("FlatJS.Component - Finding model object from HTML Nodes", function() {
+      var node = $mock.find('h2').get(0);
+
+      assert.equal(mvMod.findResourceFromNode($mock.find('h2').get(0)), APP.Person.find(2), "FlatJS.Component.findResourceFromNode works as expected");
+      assert.equal(mvMod.findResourceFromNode($mock.find('li.first-todo:eq(0)').get(0)), APP.Todo.find(1));
+    });
+
+    describe('Start Second Tests', function(done) 
+    {
+      it("FlatJS.Component - JSON update syncing", function() {
+      // reset everything
+      $('#flat-mv-test-mock').remove();
+      $('#mock-area').append(__MVMockData.HTML);
+
+      var $mock = $('#flat-mv-test-mock'),
+        $mockOne = $mock.find('.first'),
+        mockOne = $mockOne.get(0),
+        $mockTwo = $mock.find('.second'),
+        mockTwo = $mockTwo.get(0);
+
+      new FlatJS.Runner({
+        attr: 'data-js-mv-test-module'
+      });
+
+      var mvModOne = mockOne.fjsComponents ? mockOne.fjsComponents['FlatJS.Component'] : undefined,
+        mvModTwo = mockTwo.fjsComponents ? mockTwo.fjsComponents['FlatJS.Component'] : undefined;
+
+      mvModOne.fjsData.set('header.title', "Todo List - Updated");
+      mvModOne.fjsData.set('people', [{
+        personObj: APP.Person.find(2),
+        todos: [
+          APP.Todo.find(1)
+        ]
+      }]);
+
+      assert.equal(mvModOne.fjsData.header.title, "Todo List - Updated", "Updating fjsData extends the inner JSON object as expected");
+      assert.equal(mvModOne.fjsData.people[0].personObj.name, "Jane", "Updating fjsData updates the inner JSON object as expected");
+
+      assert.equal($mockOne.find('h1').text(), "Todo List - Updated", "Updating JSON object on model updates HTML in view");
+      assert.equal($mockOne.find('.person:eq(0) a').text(), 'Jane', "Array of models imported & muted successfully w/ renderFromJson");
+      assert.equal($mockOne.find('.first-todo:eq(0) span').text(), 'Get Laundry', "Todos translated over");
+
+    });
+    
+    describe('Start Third Tests', function() {
+      
+      var mvModOne, mvModTwo;
+      var $mockOne; 
+      
+      before(function(done) {
+        $.ajax({
+
+          url: 'Component/mock2.html',
+          success: function(data) {
+            $mock.remove();
+            __MVMockData.HTML2 = data
+            $('#mock-area').append(data, done);
+            
+             // Initialize 
+             $mock = $('#flat-mv-test-mock-2');
+       
+             $mockOne = $mock.find('.first'),
+             mockOne = $mockOne.get(0),
+             $mockTwo = $mock.find('.second'),
+             mockTwo = $mockTwo.get(0);
+        
+             new FlatJS.Runner({
+               attr: 'data-js-mv-test-module'
+             });
+
+             mvModOne = mockOne.fjsComponents ? mockOne.fjsComponents['FlatJS.Component'] : undefined,
+             mvModTwo = mockTwo.fjsComponents ? mockTwo.fjsComponents['FlatJS.Component'] : undefined;
+          
+            // Completed
+            done();
+          }
+        });
+      });
+      
+      it("FlatJS.Component - Relational information drawn from mockup", function() 
+      {
+         
+          assert.deepEqual(APP.Person.find(1).todos, [APP.Todo.find(1), APP.Todo.find(3)], "Object relations are set up via markup if objects are nested within each other's nodes");
+          assert.equal(APP.Person.find(1).todos.length, 2, "Object relations append correctly onto Model via markup, doesn't re-write existing objects");
+          assert.equal(APP.Person.find(2).todos.length, 1, "Object relations don't double up on assemblage");
+
+        });
+
+        it("FlatJS.Component - JSON Injection / Auto Template creation on relational models", function() {
+          // copy pasted from above set of tests, adjusting the object a bit
+          mvModOne.fjsData.set('header.title', "Todo List - Updated");
+          mvModOne.fjsData.set('people', [{
+            personObj: APP.Person.find(1)
+          }]);
+
+          assert.equal(mvModOne.fjsData.header.title, "Todo List - Updated", "updateJSON extends the inner JSON object as expected");
+
+          assert.equal($mockOne.find('h1').text(), "Todo List - Updated", "Updating JSON object on model updates HTML in view");
+          assert.equal($mockOne.find('.person:eq(0) a').text(), 'Bill', "Array of models imported & muted successfully w/ renderFromJson");
+          assert.equal($mockOne.find('.first-todo:eq(0) span').text(), 'Get Laundry', "Todos translated over");
+
+        });
+        
+        describe('Start Four test', function() {
+          before(function(done){
+            $.ajax({
+
+              url: 'Component/mock3.html',
+              success: function(data) {
+                  $mock.remove();
+                  __MVMockData.HTML3 = data;
+                  $('#mock-area').append(data);
+                  done();
+                }
+            });
+          });
+          
+          it("FlatJS.Component - Testing inputs & various node types for getter / setter functionality", function() {
+
+            new FlatJS.Runner({
+              attr: 'data-js-mv-test-module'
+            });
+
+            var $mock = $('#flat-mv-test-mock-3'),
+              mvMod = $mock.get(0).fjsComponents['FlatJS.Component'];
+
+            assert.equal(mvMod.fjsData.form.input, $mock.find('#text-input').val(), "Text input value converted to JSON");
+            assert.equal(mvMod.fjsData.form.radio, "test-radio", "Selected radio field value saved as JSON, not picking up on unselected buttons");
+            assert.equal(mvMod.fjsData.form.radioOff, false, "Radio field value converted to JSON, dashed key selectors converted to camel case");
+            assert.equal(mvMod.fjsData.form.checkbox, $mock.find('#checkbox').val(), "Checkbox value converted to JSON");
+            assert.equal(mvMod.fjsData.form.checkboxOff, false, "Checkbox value converted to JSON");
+            assert.equal(mvMod.fjsData.form.textarea, "Microphone check one two what is this", "Textarea values converted to JSON");
+
+            mvMod.fjsData.set('form', {
+              radio: "test-radio-2",
+              radioOff: true,
+              checkbox: false,
+              checkboxOff: true,
+              textarea: "The five foot assassin with the roughneck business"
+            });
+
+            mvMod.fjsData.set('form.input', 'Heyo');
+
+            assert.equal($mock.find('#text-input').val(), "Heyo", "Text input updated from JSON");
+            assert.equal($('#radio').is(':checked'), false, "Selected radio field turned off via JSON");
+            assert.equal($('#radio-2').is(':checked'), true, "Radio field value changed via JSON");
+            assert.equal($('#radio-off').is(':checked'), true, "Unselected radio field turned on via JSON");
+
+            assert.equal(mvMod.fjsData.form.radioOff, 'test-radio-off', "Unselected radio field turned on via JSON, value is imported");
+            assert.equal($('#checkbox').is(':checked'), false, "Selected checkbox turned off via JSON");
+            assert.equal($('#checkbox-off').is(':checked'), true, "Unselected checkbox turned on via JSON");
+            assert.equal(mvMod.fjsData.form.checkboxOff, 'test-checkbox-off', "Unselected checkbox text value imported via JSON.");
+            assert.equal($mock.find('textarea').val(), "The five foot assassin with the roughneck business", "Textarea values converted to JSON");
+
+            mvMod.fjsData.set('form.checkbox', "new value");
+
+            assert.equal($('#checkbox').val(), "new value", "New value set onto checkbox");
+            assert.ok($('#checkbox').is(':checked'), "Checkbox set on by setting a non false value");
+
+            $mock.remove();
+          });
+
+          it("FlatJS.Component - Testing 2 way binding on input types", function() {
+            $('#mock-area').append(__MVMockData.HTML3);
+
+            new FlatJS.Runner({
+              attr: 'data-js-mv-test-module'
+            });
+
+            var $mock = $('#flat-mv-test-mock-3'),
+              mvMod = $mock.get(0).fjsComponents['FlatJS.Component'];
+
+            var e = jQuery.Event("keyup");
+            e.which = 50;
+            e.keyCode = 50;
+            $('#text-input').val($('#text-input').val() + 'a');
+            $('#text-input').trigger(e);
+
+            assert.equal(mvMod.fjsData.form.input, "testa", "Internal JSON data object updated when text input is updated on keyup");
+
+            var e = jQuery.Event("keyup");
+            e.which = 50;
+            e.keyCode = 50;
+            $('#text-input').val($('#text-input').val() + 'a');
+            $('#text-input').trigger(e);
+            assert.equal(mvMod.fjsData.form.input, "testaa", "Internal JSON data object updated when text input is updated on keyup");
+
+            $('#radio-2').trigger('click');
+            assert.equal(mvMod.fjsData.form.radio, "test-radio-2", "Internal JSON data object updated when radio button is updated on click");
+
+            $('#checkbox').trigger('click');
+            $('#checkbox-off').trigger('click');
+            assert.equal(mvMod.fjsData.form.checkbox, false, "Internal JSON data object updated when checkbox button is updated on click");
+            assert.equal(mvMod.fjsData.form.checkboxOff, "test-checkbox-off", "Internal JSON data object updated when checkbox button is updated on click");
+
+            var e = jQuery.Event("keyup");
+            e.which = 50;
+            e.keyCode = 50;
+            $mock.find('textarea').val($('textarea').val() + 'a');
+            $mock.find('textarea').trigger(e);
+            assert.equal(mvMod.fjsData.form.textarea, "Microphone check one two what is thisa", "Internal JSON data object updated when textarea is updated on keyup");
+
+            $mock.remove();
+          });
+          
+          describe('Start fifth tests', function() {
+              
+              before(function(done)
+              {
+                $('#mock-area').append(__MVMockData.HTML);
+
+                new FlatJS.Runner({
+                  attr: 'data-js-mv-test-module'
+                });
+
+                $mock = $('#flat-mv-test-mock'),
+                mvMod = $mock.find('.first').get(0).fjsComponents['FlatJS.Component'];
+                
+                done();
+              });
+            
+              it("FlatJS.Component - Deleting and updating model object behavoir & cleanup", function() {
+                APP.Person.find(2).remove();
+
+                assert.equal($mock.find('.first h2').length, 0, "Deleting model object also removes references in dom");
+                assert.equal($mock.find('.first [fjs-obj="you"]').length, 0, "Deleting model object also removes references in dom");
+                assert.equal($mock.find('.first [fjs-resource="APP.Person"][fjs-id="2"]').length, 0, "Deleting model object also removes references in dom");
+                assert.equal(mvMod.fjsData.you, undefined, "Related object is removed from component's fjsData if model is removed");
+                // Minor tweak: people is undefined, and not people.persObj
+                assert.equal(typeof mvMod.fjsData.people[1], 'undefined', "Related object is removed from component's fjsDataif model is removed");
+          //
+                mvMod.fjsData.push('people', {
+                  personObj: APP.Person.find(1),
+                  todos: [
+                    APP.Person.find(1).todos
+                  ]
+                });
+                APP.Person.find(1).remove();
+
+                assert.equal($mock.find('.first [fjs-resource="APP.Person"][fjs-id="1"]').length, 0, "Deleting model object also removes references in dom");
+
+                $mock.remove();
+              });
+            });
+          });
+        
+    });
+  });
+});

--- a/test/Component/mock.html
+++ b/test/Component/mock.html
@@ -1,0 +1,101 @@
+<div id="flat-mv-test-mock">
+
+  <div class="first" data-js-mv-test-module="FlatJS.Component">
+
+    <div fjs-key="arbitrary-root-key">Valuable</div>
+    <div id="root-class-swap" class="true" fjs-class='["arbitrary-root-key", "Not Valuable", "true", "false"]'></div>
+
+    <div fjs-obj="header">
+      <h1 fjs-key="title">Todo List</h1>
+      <h5 fjs-key="arbitrary-top-title">Hey now</h5>
+      <h5 fjs-key="arbitrary-top-title-2">Hey now</h5>
+      <div id="inner-item-class-swap" class="true" fjs-class='["arbitrary-top-title-2", "Hey Hey", "true", "false"]'></div>
+    </div>
+
+    <div fjs-obj="you" fjs-id="2" fjs-resource="APP.Person">
+      <div>
+        <div>
+          <h2 fjs-key="name"></h2>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <div fjs-array="people">
+        <!-- actual data -->
+        <div>
+          <div fjs-obj="person-obj" fjs-id="1" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Bill</a>
+          </div>
+          <ul fjs-array="todos">
+            <li class="first-todo" fjs-resource="APP.Todo" fjs-id="1" fjs-json='{ "arbitrary": "key values", "completed": true }' fjs-class='["completed", true, "completed"]'>
+              <span fjs-key="title">Get Laundry</span>
+            </li>
+            <li fjs-resource="APP.Todo" fjs-id="31" fjs-json='{ "arbitrary": "key values" }' fjs-class='["completed", true, "completed"]' class="completed">
+              <span fjs-key="title">Get Laundryz</span>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div fjs-obj="personObj" fjs-id="2" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Jane</a>
+          </div>
+          <ul fjs-array="todos">
+            <li>
+              <span fjs-key="title">Get Dinner</span>
+            </li>
+            <li>
+              <span fjs-key="title">Get Dinner</span>
+            </li>
+            <li>
+              <span fjs-key="title">Get Dinner</span>
+            </li>
+            <li>
+              <span fjs-key="title">Get Dinner</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="second" data-js-mv-test-module="FlatJS.Component">
+
+    <div fjs-obj="header">
+      <h1 fjs-key="title">Todo List</h1>
+    </div>
+
+    <div fjs-obj="you" fjs-id="1" fjs-resource="APP.Person" class="person">
+      <h2 fjs-key="name">fdsfsadfsa</h2>
+    </div>
+
+    <div>
+      <div fjs-array="people">
+        <!-- actual data -->
+        <div>
+          <div fjs-obj="personObj" fjs-id="2" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Jane</a>
+          </div>
+          <ul fjs-array="todos">
+            <li class="first-todo" fjs-resource="APP.Todo" fjs-id="2" fjs-json='{ "completed": false }' fjs-class='["completed", true, "completed", "not-completed"]'>
+              <span fjs-key="title">Get Dinner</span>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div fjs-id="1" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Bill</a>
+          </div>
+          <ul fjs-array="todos">
+            <li fjs-resource="APP.Todo" fjs-id="3" fjs-json='{ "completed": false, "whatever": true }' fjs-class='[["completed", true, "completed", "not-completed"], ["whatever", true, "whatever"]]'>
+              <span fjs-key="title">Get Chicken</span>
+              <span fjs-key="something-extra">hey</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/test/Component/mock2.html
+++ b/test/Component/mock2.html
@@ -1,0 +1,88 @@
+<div id="flat-mv-test-mock-2">
+
+  <div class="first" data-js-mv-test-module="FlatJS.Component">
+
+    <div fjs-obj="header">
+      <h1 fjs-key="title">Todo List</h1>
+    </div>
+
+    <div fjs-obj="you" fjs-id="2" fjs-resource="APP.Person">
+      <h2 fjs-key="name"></h2>
+    </div>
+
+    <div>
+      <div fjs-array="people">
+        <!-- actual data -->
+        <div>
+          <div fjs-obj="personObj" fjs-id="1" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Bill</a>
+            <ul fjs-array="todos">
+              <li class="first-todo" fjs-resource="APP.Todo" fjs-id="1" fjs-json='{ "arbitrary": "key values" }'>
+                <span fjs-key="title">Get Laundry</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div>
+          <div fjs-obj="personObj" fjs-id="2" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Jane</a>
+            <ul fjs-array="todos">
+              <li>
+                <span fjs-key="title">Get Dinner</span>
+              </li>
+              <li>
+                <span fjs-key="title">Get Dinner</span>
+              </li>
+              <li>
+                <span fjs-key="title">Get Dinner</span>
+              </li>
+              <li>
+                <span fjs-key="title">Get Dinner</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="second" data-js-mv-test-module="FlatJS.Component">
+
+    <div fjs-obj="header">
+      <h1 fjs-key="title">Todo List</h1>
+    </div>
+
+    <div fjs-obj="you" fjs-id="1" fjs-resource="APP.Person" class="person">
+      <h2 fjs-key="name">fdsfsadfsa</h2>
+    </div>
+
+    <div>
+      <div fjs-array="people">
+        <!-- actual data -->
+        <div>
+          <div fjs-obj="personObj" fjs-id="2" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Jane</a>
+            <ul fjs-array="todos">
+              <li class="first-todo" fjs-resource="APP.Todo" fjs-id="2">
+                <span fjs-key="title">Get Dinner</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div>
+          <div fjs-id="1" fjs-resource="APP.Person" class="person">
+            <a fjs-key="name" href="#">Bill</a>
+            <ul fjs-array="todos">
+              <li fjs-resource="APP.Todo" fjs-id="3">
+                <span fjs-key="title">Get Chicken</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+

--- a/test/Component/mock3.html
+++ b/test/Component/mock3.html
@@ -1,0 +1,13 @@
+<div id="flat-mv-test-mock-3" data-js-mv-test-module="FlatJS.Component">
+
+  <form fjs-obj="form">
+    <input id="text-input" type="text" fjs-key="input" value="test" />
+    <input id="radio" type="radio" name="radio-input" fjs-key="radio" value="test-radio" checked="checked" />
+    <input id="radio-2" type="radio" name="radio-input" fjs-key="radio" value="test-radio-2" />
+    <input id="radio-off" type="radio" fjs-key="radio-off" value="test-radio-off" />
+    <input id="checkbox" type="checkbox" fjs-key="checkbox" checked="checked" value="test-checkbox" />
+    <input id="checkbox-off" type="checkbox" fjs-key="checkbox-off" value="test-checkbox-off" />
+    <textarea fjs-key="textarea">Microphone check one two what is this</textarea>
+  </form>
+
+</div>

--- a/test/Dispatch/Dispatch.tests.js
+++ b/test/Dispatch/Dispatch.tests.js
@@ -1,0 +1,143 @@
+// should contain all unit tests on FlatJS.Dispatch.js
+
+describe('All unit tests on FlatJS.Dispatch.js', function()
+{
+
+it("FlatJS.Dispatch existence & FlatJS.Classy.prototype extension tests", function() {
+
+  assert.equal(typeof FlatJS.Dispatch, 'object', "FlatJS.Dispatch exists, is an object");
+  assert.equal(typeof FlatJS.Classy.prototype.publish, 'function', "FlatJS.Classy.prototype.publish exists, extending properly");
+  assert.equal(typeof FlatJS.Classy.prototype.subscribe, 'function', "FlatJS.Classy.prototype.subscribe exists, extending properly");
+  assert.equal(typeof FlatJS.Classy.prototype.unsubscribe, 'function', "FlatJS.Classy.prototype.unsubscribe exists, extending properly");
+
+});
+
+it("FlatJS.Dispatch pubsub tests", function(done) {
+
+  var calledOnce = false;
+
+  function publishCallback(int1, int2) {
+    if (calledOnce) {
+      assert.ok(false, "Callback fired more than once, unsubscribe not working");
+    } else {
+      calledOnce = true;
+      assert.ok(true, "Callback successfully fires after publish call is made");
+      assert.equal(int1, 3, "Int1 passed back correctly as argument to callback");
+      assert.equal(int2, 4, "Int2 passed back correctly as argument to callback");
+      //QUnit.start();
+      done();
+    }
+  }
+
+  FlatJS.Dispatch.subscribe('test-publish', publishCallback);
+  FlatJS.Dispatch.publish('test-publish', [3, 4]);
+
+  FlatJS.Dispatch.unsubscribe('test-publish', publishCallback);
+
+  //should throw an error if above unsubscribe call didn't work
+  FlatJS.Dispatch.publish('test-publish', [2,3]);
+
+  FlatJS.Dispatch.subscribe('test-publish', publishCallback);
+  FlatJS.Dispatch.unsubscribe('test-publish');
+
+  //should throw an error if above unsubscribe call didn't work
+  FlatJS.Dispatch.publish('test-publish', [2,3]);
+
+});
+
+it("FlatJS.Dispatch pubsub contextual to 'this' using apply", function(done) {
+
+  var calledOnce = false;
+
+  var obj = {
+    int1: 33,
+    int2: 44
+  };
+
+  function publishCallback(int1, int2) {
+    if (calledOnce) {
+      assert.ok(false, "Callback fired more than once, unsubscribe not working");
+    } else {
+      calledOnce = true;
+      assert.ok(true, "Callback successfully fires after publish call is made");
+      assert.equal(int1, 3, "Int1 passed back correctly as argument to callback");
+      assert.equal(int2, 4, "Int2 passed back correctly as argument to callback");
+      assert.equal(this.int1, 33, "this.int1 verified, Dispatch successfully passes context to callback");
+      assert.equal(this.int2, 44, "this.int2 verified, Dispatch successfully passes context to callback");
+      done();
+    }
+  }
+
+  FlatJS.Dispatch.subscribe.apply(obj, ['test-publish', publishCallback]);
+  FlatJS.Dispatch.publish.apply(obj, ['test-publish', [3, 4]]);
+
+  FlatJS.Dispatch.unsubscribe.apply(obj, ['test-publish', publishCallback]);
+
+  //should throw an error if above unsubscribe call didn't work
+  FlatJS.Dispatch.publish.apply(obj, ['test-publish', [2, 3]]);
+
+  FlatJS.Dispatch.subscribe.apply(obj, ['test-publish', publishCallback]);
+  FlatJS.Dispatch.unsubscribe.apply(obj, ['test-publish']);
+
+  //should throw an error if above unsubscribe call didn't work
+  FlatJS.Dispatch.publish.apply(obj, ['test-publish', [2, 3]]);
+
+  FlatJS.Dispatch.subscribe.apply(obj, ['test-publish', publishCallback]);
+  FlatJS.Dispatch.unsubscribe.apply(obj);
+
+  //should throw an error if above unsubscribe call didn't work
+  FlatJS.Dispatch.publish.apply(obj, ['test-publish', [2, 3]]);
+
+});
+
+it("FlatJS.Dispatch pubsub contextual to FlatJS.Classy objects", function() {
+
+  var calledOnce = false;
+
+  var objClass = FlatJS.Classy.extend({
+    int1: 0,
+    int2: 0,
+    init: function(int1, int2) {
+      this.int1 = int1;
+      this.int2 = int2;
+    }
+  })
+
+  var obj = new objClass(33, 44);
+
+  function publishCallback(int1, int2) {
+    if (calledOnce) {
+      assert.ok(false, "Callback fired more than once, unsubscribe not working");
+    } else {
+      calledOnce = true;
+      assert.ok(true, "Callback successfully fires after publish call is made");
+      assert.equal(int1, 3, "Int1 passed back correctly as argument to callback");
+      assert.equal(int2, 4, "Int2 passed back correctly as argument to callback");
+      assert.equal(this.int1, 33, "this.int1 verified, Dispatch successfully passes context to callback");
+      assert.equal(this.int2, 44, "this.int2 verified, Dispatch successfully passes context to callback");
+    //  QUnit.start();
+    }
+  }
+
+  obj.subscribe('test-publish', publishCallback);
+  obj.publish('test-publish', [3, 4]);
+
+  obj.unsubscribe('test-publish', publishCallback);
+
+  //should throw an error if above unsubscribe call didn't work
+  obj.publish('test-publish', [2, 3]);
+
+  obj.subscribe('test-publish', publishCallback);
+  obj.unsubscribe('test-publish');
+
+  //should throw an error if above unsubscribe call didn't work
+  obj.publish('test-publish', [2, 3]);
+
+  obj.subscribe('test-publish', publishCallback);
+  obj.unsubscribe();
+
+  //should throw an error if above unsubscribe call didn't work
+  obj.publish('test-publish', [2, 3]);
+
+});
+});

--- a/test/Resource/Resource.tests.js
+++ b/test/Resource/Resource.tests.js
@@ -1,0 +1,91 @@
+// should contain all tests for FlatJS.Resource
+
+describe('FlatJS.Resource', function()
+{
+it("FlatJS.Resource existence tests", function() {
+
+  assert.equal(typeof FlatJS.Resource, 'function', 'FlatJS.Resource exists and is a function');
+  assert.equal(typeof FlatJS.Resource.extend, 'function', 'FlatJS.Resource exists and has an inherited extend function');
+  assert.ok(FlatJS.Resource.prototype instanceof FlatJS.Classy, 'FlatJS.Resource inherits FlatJS.Classy');
+
+});
+
+it("FlatJS.Resource construction, setter, watch, and unwatch functionality", function(done) {
+
+  // adds an object with an ID to ensure
+  // object X does some work
+  var y = new FlatJS.Resource({
+    id: 1,
+    nest: {
+      val: 'heh'
+    }
+  });
+  var x      = new FlatJS.Resource();
+
+  function watchCallback(val, oldVal, name, obj) {
+    assert.ok(true, "callback on watch function successful");
+    assert.equal(val, 3, "callback on watch function successfully returns changed new value");
+    assert.equal(typeof x.id, "number", "temporary ID created");
+    assert.equal(oldVal, undefined, "callback on watch function successfully retains old value");
+    assert.equal(name, 'g', "callback on watch function successfully retains name of property");
+    assert.equal(obj, x, "initial object passed through callback");
+  }
+
+  function watchNumArrayCallback(val, oldVal, name, obj) {
+    assert.ok(true, "Pushing an object triggers the callback");
+    assert.deepEqual(val, [2,3,5], "FlatJS.Resource.prototype.push function works as expected");
+    assert.deepEqual(oldVal, [2,3], "Old value retained on push");
+  }
+
+  function getNestedValueCallback(val, oldVal, name, obj) {
+    assert.ok(true, "Nested values can be set and trigger callbacks");
+    assert.equal(val, 'heyo', "Nested value changed in callback");
+    assert.deepEqual(obj.nest, { val: 'heyo' }, "Nested object changed on object");
+    //QUnit.start();
+    done();
+  }
+
+  x.watch('g', watchCallback);
+
+  x.set('g', 3);
+
+  assert.equal(x.g, 3, "x.set() sets a variable on the object, successfully mutes actual object");
+
+  x.unwatch('g', watchCallback);
+
+  // will trigger errors if above unwatch call was unsucessful due to check on oldVal.
+  x.set('g', 3);
+
+  x.watch('g', watchCallback);
+
+  // check to see if all handlers get deleted by key
+  x.unwatch('g');
+
+  // will trigger errors if above unwatch call was unsucessful due to check on oldVal.
+  x.set('g', 3);
+
+  x.set('numArray', [2,3]);
+
+  x.watch('numArray', watchNumArrayCallback);
+
+  x.push('numArray', 5);
+
+  y.watch('nest.val', getNestedValueCallback);
+
+  y.set('nest.val', 'heyo');
+});
+
+it("FlatJS.Resource static query functions", function() {
+
+  var exClass = FlatJS.Resource.extend();
+
+  for (var id = 0; id < 10; id++) {
+    new exClass({
+      id: id
+    });
+  }
+
+  assert.equal(exClass.find(1), exClass.fjsObjects[1], "Objects have static find method which looks in class' objects variable for matching ID values");
+
+});
+});

--- a/test/Runner/Runner.tests.js
+++ b/test/Runner/Runner.tests.js
@@ -1,0 +1,113 @@
+// tests for module runner
+
+// stores info for tests
+var __moduleRunnerMockData;
+
+describe('Runner test',  function()
+{
+
+  before(function(done)
+  {
+
+    __moduleRunnerMockData = {
+
+      HTML: '',
+
+      moduleOne: function(obj) {
+        this.int1 = 33;
+        this.int2 = 55;
+
+        obj.innerHTML = obj.innerHTML + '<p>Module One.</p>';
+      },
+
+      nested: {
+        moduleTwo: FlatJS.Classy.extend({
+          init: function(obj) {
+            this.int1 = 23;
+            this.int2 = 89;
+
+            obj.innerHTML = obj.innerHTML + '<p>Module Two.</p>';
+          }
+        }),
+      },
+
+      basicImplentationTests: function(mock, obj2, nodeSet, done) {
+          assert.ok(mock.fjsComponents, "fjsComponents array attaches to <div> on init, init runs by default, works without provided scope");
+          assert.ok(mock.fjsComponents[!nodeSet ? '__moduleRunnerMockData.moduleOne' : 'moduleOne'] instanceof __moduleRunnerMockData.moduleOne, "moduleOne module executed on div, retrieves object and is instance of __moduleRunnerMockData.moduleOne");
+
+          assert.ok(obj2.fjsComponents, "jsModules array attaches to <div> on inner <div> recursively");
+
+          assert.ok(obj2.fjsComponents[!nodeSet ? '__moduleRunnerMockData.nested.moduleTwo' : 'nested.moduleTwo'] instanceof __moduleRunnerMockData.nested.moduleTwo, "moduleTwo is assigned appropriately to inner <div>");
+          assert.equal(obj2.fjsComponents[!nodeSet ? '__moduleRunnerMockData.nested.moduleTwo' : 'nested.moduleTwo'].int1, 23, "reference to inner object returns correctly set variable retrieved from data attribute");
+          
+          // Completed
+          done();
+      }
+
+    };
+    
+    // Ajax call
+    $.ajax({
+      url: './Runner/mock.html',
+      success: function(data) {
+        __moduleRunnerMockData.HTML = data;
+        $('#mock-area').append(data);
+        //__moduleRunnerMockData.mockLoadedCallback()
+        done();
+      }
+    });
+  });
+
+
+  it("FlatJS.Runner default functionality", function(done) {
+
+    var $mock = $('#module-runner-test-mock'),
+        $two  = $mock.find('.module-two'),
+        mock  = $mock.get(0),
+        obj2  = $two.get(0);
+
+    var runner = new FlatJS.Runner();
+
+    assert.ok($('#module-runner-test-mock').length > 0, "Module runner mock HTML loads and appends via ajax");
+
+    __moduleRunnerMockData.basicImplentationTests(mock, obj2, false, done);
+
+  });
+
+  // reset
+  it('FlatJS.Runner - extended functionality', function(done) {
+
+    var $mock = $('#module-runner-test-mock');
+
+    assert.equal(__moduleRunnerMockData.HTML.length, 188)
+    //reset
+    $mock.remove();
+    $('#mock-area').append(__moduleRunnerMockData.HTML);
+
+    var $mock = $('#module-runner-test-mock'),
+        $two  = $mock.find('.module-two'),
+        mock  = $mock.get(0),
+        obj2  = $two.get(0);
+
+    // edit attributes
+    $mock.attr('data-new-js-module', 'module-one');
+    $two.attr('data-new-js-module', 'nested.module-two');
+
+    var runner = new FlatJS.Runner({
+      init:    false,
+      context: __moduleRunnerMockData,
+      attr:    'data-new-js-module',
+      node:    mock
+    })
+
+   //TODO fix it
+     assert.equal(typeof obj2.jsModules, 'undefined', "Runner does not automatically init if false flag is passed");
+
+    runner.init();
+
+    __moduleRunnerMockData.basicImplentationTests(mock, obj2, true, done);
+
+    $mock.remove();
+
+  });
+});

--- a/test/Runner/mock.html
+++ b/test/Runner/mock.html
@@ -1,0 +1,7 @@
+<div id="module-runner-test-mock" fjs-component="__moduleRunnerMockData.module-one">
+
+  <div class="module-two" fjs-component="__moduleRunnerMockData.nested.module-two">
+
+  </div>
+
+</div>

--- a/test/Widget/Widget.tests.js
+++ b/test/Widget/Widget.tests.js
@@ -1,0 +1,76 @@
+
+// tests for FlatJS.Widget
+describe('FlatJS.Widget', function()
+{
+  var __widgetMockData;
+  
+  beforeEach(function(done)
+  {
+    __widgetMockData = {
+
+      HTML: '',
+      exampleWidget: FlatJS.Widget.extend({
+        initializer: function() {
+          this.initialized = true;
+        },
+        renderUI: function() {
+          this.renderUIed = true;
+        },
+        syncUI: function() {
+          this.syncUIed = true;
+        },
+        bindUI: function() {
+          this.bindUIed = true;
+        }
+      })
+
+    }
+
+    __widgetMockData.nonRenderingWidget =  __widgetMockData.exampleWidget.extend(
+    {
+      renderOnInit: false
+    });
+    
+    $.ajax({
+      url: './Widget/mock.html',
+      success: function(data) 
+      {
+        __widgetMockData.HTML = data;
+        $('#mock-area').append(data);
+        // Mark as completed
+        done();
+      }
+    });
+  });
+
+
+  it("FlatJS.Widget - Tests lifecycle", function(done) {    
+    var $mock = $('#flat-widget-mock');
+
+    assert.ok(true, "mock widget file loaded");
+    assert.equal($mock.length, 1, "Mock object exists in DOM")
+
+    var x = new __widgetMockData.exampleWidget($mock.get(0));
+
+    assert.equal(x.initialized, true, "x.initializer() fires on object construction");
+    assert.equal(x.renderUIed, true, "x.renderUI() fires on object construction");
+    assert.equal(x.syncUIed, true, "x.syncUI() fires on object construction");
+    assert.equal(x.bindUIed, true, "x.bindUI() fires on object construction");
+    assert.equal(x.fjsRootNode, $mock.get(0), "x.fjsRootNode is equal to the node passed on constructing x");
+
+    var y = new __widgetMockData.nonRenderingWidget($mock.get(0));
+
+    assert.equal(y.initialized, undefined, "y should not render immediately");
+    assert.equal(y.fjsRootNode, $mock.get(0), "y.fjsRootNode is equal to the node passed on constructing y");
+
+    y.render();
+
+    assert.equal(y.initialized, true, "y.initializer() fires on object construction");
+    assert.equal(y.renderUIed, true, "y.renderUI() fires on object construction");
+    assert.equal(y.syncUIed, true, "y.syncUI() fires on object construction");
+    assert.equal(y.bindUIed, true, "y.bindUI() fires on object construction");
+    
+    done();
+  });
+
+});

--- a/test/Widget/mock.html
+++ b/test/Widget/mock.html
@@ -1,0 +1,3 @@
+<div id="flat-widget-mock">
+  <h1></h1>
+</div>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,58 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  </head>
+  <a href="index.html" id="" title="index">index</a>
+  <body>
+    
+    <div id="mocha"></div>
+
+    <div id="mock-area"></div>
+    
+    <script src="../node_modules/jquery/dist/jquery.js"></script>
+    
+    <!-- Testing framework -->
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    
+
+    <script src="../src/FlatJS.js"></script>
+    <script src="../src/FlatJS.Classy.js"></script>
+    <script src="../src/FlatJS.Helpers.js"></script>
+    <script src="../src/FlatJS.Dispatch.js"></script>
+    <script src="../src/FlatJS.Resource.js"></script>
+    <script src="../src/FlatJS.Runner.js"></script>
+    <script src="../src/FlatJS.Widget.js"></script>
+    <script src="../src/FlatJS.Component.js"></script>
+    
+    <script>
+      mocha.ui('bdd');
+      mocha.reporter('html');
+      var assert = chai.assert;
+    </script>
+      
+    <!-- Script 
+    <script src="Classy/Classy.tests.js"></script>
+    <script src="Dispatch/Dispatch.tests.js"></script>
+    <script src="Resource/Resource.tests.js"></script>
+    <script src="Runner/Runner.tests.js"></script>
+    <script src="Widget/Widget.tests.js"></script>
+    -->
+    <script src="Component/Component.tests.js"></script> 
+  
+    
+    <!-- Mocha -->
+    <script>
+      if (window.mochaPhantomJS) 
+      { 
+        mochaPhantomJS.run(); 
+      }
+      else 
+      { 
+        mocha.run(); 
+      }
+    </script>
+      
+  </body>
+</html>


### PR DESCRIPTION
Well I have migrate the test to Mocha / chaijs + mocha-phantomjs.
You might need to install mocha-phantomjs as standalone.
$npm install -g mocha-phantomjs

I moved the tests to test/ to follow mocha naming convention.
Also, I have created a script entry for test in the package.json, this enables to run the regression with:
$npm test

I had to modify only a single line of actual test.
I have re-implemented Component test in BDD style.

Let me know if you have any questions.

Link:
https://www.bountysource.com/issues/11170504-convert-tests-from-qunit-to-mocha-teaspoon/developers
